### PR TITLE
Feature: README shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-# RedFlags public facing website
+# RedFlags Public Facing Website
 
-[![CircleCI](https://circleci.com/gh/slovensko-digital/redflags.slovensko.digital.svg?style=shield)](https://circleci.com/gh/slovensko-digital/redflags.slovensko.digital)
-[![Dependency Status](https://gemnasium.com/slovensko-digital/redflags.slovensko.digital.png)](https://gemnasium.com/slovensko-digital/redflags.slovensko.digital)
-[![Code Climate](https://codeclimate.com/github/slovensko-digital/redflags.slovensko.digital.png)](https://codeclimate.com/github/slovensko-digital/redflags.slovensko.digital)
-[![Test Coverage](https://codeclimate.com/github/slovensko-digital/redflags.slovensko.digital/badges/coverage.svg)](https://codeclimate.com/github/slovensko-digital/redflags.slovensko.digital/coverage)
-[![Inch CI](https://inch-ci.org/github/slovensko-digital/redflags.slovensko.digital.svg)](https://inch-ci.org/github/slovensko-digital/redflags.slovensko.digital)
-
+[![CircleCI](https://img.shields.io/circleci/project/github/slovensko-digital/redflags.slovensko.digital.svg)](https://circleci.com/gh/slovensko-digital/redflags.slovensko.digital)
+[![Gemnasium](https://img.shields.io/gemnasium/slovensko-digital/redflags.slovensko.digital.svg)](https://gemnasium.com/slovensko-digital/redflags.slovensko.digital)
+[![Code Climate](https://img.shields.io/codeclimate/coverage/github/slovensko-digital/redflags.slovensko.digital.svg)](https://codeclimate.com/github/slovensko-digital/redflags.slovensko.digital)

--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 [![CircleCI](https://img.shields.io/circleci/project/github/slovensko-digital/redflags.slovensko.digital.svg)](https://circleci.com/gh/slovensko-digital/redflags.slovensko.digital)
 [![Gemnasium](https://img.shields.io/gemnasium/slovensko-digital/redflags.slovensko.digital.svg)](https://gemnasium.com/slovensko-digital/redflags.slovensko.digital)
-[![Code Climate](https://img.shields.io/codeclimate/coverage/github/slovensko-digital/redflags.slovensko.digital.svg)](https://codeclimate.com/github/slovensko-digital/redflags.slovensko.digital)
+[![Code Climate](https://img.shields.io/codeclimate/github/slovensko-digital/redflags.slovensko.digital.svg)](https://codeclimate.com/github/slovensko-digital/redflags.slovensko.digital)
+[![Test Coverage](https://img.shields.io/codeclimate/coverage/github/slovensko-digital/redflags.slovensko.digital.svg)](https://codeclimate.com/github/slovensko-digital/redflags.slovensko.digital/coverage)


### PR DESCRIPTION
- switch to shields.io for consistently looking badges
- drop Code Climate version badge, not needed duplicate
- drop Inch CI, not needed for now