### PR TITLE
Implement tag filtering, resolves #115

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,10 +11,8 @@ class ProjectsController < ApplicationController
     @rating_types_by_phase = RatingType.all.group_by(&:rating_phase)
     @selected_tag = params[:tag]
 
-    if ProjectsHelper::ALLOWED_TAGS.map { |tag, translated| tag }.include? params[:tag]
-      @projects = Project.published.joins(published_revision: :revision)
-        .where(":tags = ANY(revisions.tags)", tags: params[:tag])
-        .map { |p| p.published_revision }.sort_by(&:aggregated_rating)
+    if ProjectsHelper::ALLOWED_TAGS.keys.include? params[:tag]
+      @projects = Project.published.with_tag(params[:tag]).map { |p| p.published_revision }.sort_by(&:aggregated_rating)
     
     else
       @projects = Project.published.map { |p| p.published_revision }.sort_by(&:aggregated_rating)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -10,5 +10,15 @@ class ProjectsController < ApplicationController
   def index
     @rating_types_by_phase = RatingType.all.group_by(&:rating_phase)
     @projects = Project.published.map { |p| p.published_revision }.sort_by(&:aggregated_rating)
+
+    @filter = {
+      "tag" => nil,
+      "available" => ProjectsHelper::available_tags,
+    }
+
+    if ProjectsHelper::available_tags.map { |tag, translated| tag }.include? params[:tag]
+      @projects = @projects.select {|p| p.tags.include? params[:tag]}
+      @filter["tag"] = params[:tag]
+    end
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,12 +11,8 @@ class ProjectsController < ApplicationController
     @rating_types_by_phase = RatingType.all.group_by(&:rating_phase)
     @selected_tag = params[:tag]
 
-    if ProjectsHelper::ALLOWED_TAGS.keys.include? params[:tag]
-      @projects = Project.published.with_tag(params[:tag]).map { |p| p.published_revision }.sort_by(&:aggregated_rating)
-    
-    else
-      @projects = Project.published.map { |p| p.published_revision }.sort_by(&:aggregated_rating)
-    
-    end
+    @projects = Project.published
+    @projects = @projects.with_tag(params[:tag]) if ProjectsHelper::ALLOWED_TAGS.keys.include?(params[:tag])
+    @projects = @projects.map { |p| p.published_revision }.sort_by(&:aggregated_rating)
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -9,16 +9,15 @@ class ProjectsController < ApplicationController
 
   def index
     @rating_types_by_phase = RatingType.all.group_by(&:rating_phase)
-    @projects = Project.published.map { |p| p.published_revision }.sort_by(&:aggregated_rating)
+    @selected_tag = params[:tag]
 
-    @filter = {
-      "tag" => nil,
-      "available" => ProjectsHelper::available_tags,
-    }
-
-    if ProjectsHelper::available_tags.map { |tag, translated| tag }.include? params[:tag]
-      @projects = @projects.select {|p| p.tags.include? params[:tag]}
-      @filter["tag"] = params[:tag]
+    if ProjectsHelper::ALLOWED_TAGS.map { |tag, translated| tag }.include? params[:tag]
+      @projects = Project.published.select {|p| p.published_revision.tags.include? params[:tag]}
+        .map { |p| p.published_revision }.sort_by(&:aggregated_rating)
+    
+    else
+      @projects = Project.published.map { |p| p.published_revision }.sort_by(&:aggregated_rating)
+    
     end
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -12,7 +12,8 @@ class ProjectsController < ApplicationController
     @selected_tag = params[:tag]
 
     if ProjectsHelper::ALLOWED_TAGS.map { |tag, translated| tag }.include? params[:tag]
-      @projects = Project.published.select {|p| p.published_revision.tags.include? params[:tag]}
+      @projects = Project.published.joins(published_revision: :revision)
+        .where(":tags = ANY(revisions.tags)", tags: params[:tag])
         .map { |p| p.published_revision }.sort_by(&:aggregated_rating)
     
     else

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -41,4 +41,16 @@ module ProjectsHelper
       end
     end
   end
+
+  def self.available_tags
+    {
+      "hodnotene-sd" => "Hodnotené tímom Slovensko.Digital",
+      "hodnotene-rfza" => "Hodnotené tímom Žilina",
+      "hodnotene-komunitou" => "Hodnotené Komunitou",
+    }
+  end
+
+  def translate_tags(tags)
+    tags.map { |tag| ProjectsHelper::available_tags[tag] }
+  end
 end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -42,15 +42,9 @@ module ProjectsHelper
     end
   end
 
-  def self.available_tags
-    {
-      "hodnotene-sd" => "Hodnotené tímom Slovensko.Digital",
-      "hodnotene-rfza" => "Hodnotené tímom Žilina",
-      "hodnotene-komunitou" => "Hodnotené Komunitou",
-    }
-  end
-
-  def translate_tags(tags)
-    tags.map { |tag| ProjectsHelper::available_tags[tag] }
-  end
+  ALLOWED_TAGS = {
+    "hodnotene-sd" => "Hodnotené tímom Slovensko.Digital",
+    "hodnotene-rfza" => "Hodnotené tímom Žilina",
+    "hodnotene-komunitou" => "Hodnotené Komunitou",
+  }
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,7 +28,7 @@ class Project < ApplicationRecord
   belongs_to :published_revision, class_name: 'ProjectRevision', optional: true
 
   scope :published, -> { where('published_revision_id IS NOT NULL') }
-  scope :with_tag, -> (tag) { joins(published_revision: :revision).where(":tags = ANY(revisions.tags)", tags: tag) }
+  scope :with_tag, -> (tag) { joins(published_revision: :revision).where("? = ANY(revisions.tags)", tag) }
 
   enum category: { good: 0, bad: 1, boring: 2 }
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,6 +28,7 @@ class Project < ApplicationRecord
   belongs_to :published_revision, class_name: 'ProjectRevision', optional: true
 
   scope :published, -> { where('published_revision_id IS NOT NULL') }
+  scope :with_tag, -> (tag) { joins(published_revision: :revision).where(":tags = ANY(revisions.tags)", tags: tag) }
 
   enum category: { good: 0, bad: 1, boring: 2 }
 end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -2,6 +2,22 @@
   <h1 class="mt-5 mb-3">Zoznam hodnotených projektov</h1>
   <p class="lead"><strong>Chýba Vám tu nejaký projekt? Nezdá sa Vám hodnotenie?</strong> Toto hodnotenie je možné <%= link_to 'dopĺňať a upravovať', contribute_path %>.</p>
 
+  <form action=<%= projects_path %>>
+    <div class="form-row">
+      <div class="form-group mb-2 col-sm-4">
+        <select name="tag" class="form-control">
+          <option value="">Všetky tagy</option>
+          <% @filter["available"].each do |tag, translated| %>
+            <option value="<%= tag %>" <%= @filter["tag"] == tag ? 'selected' : '' %>><%= translated %></option>
+          <% end %>
+        </select>
+      </div>
+      <div class="form-group mb-2 col-sm-2">
+        <input type="submit" value="Filtrovať podľa tagu" class="btn mb-2">
+      </div>
+    </div>
+  </form>
+
   <ul class="nav nav-pills mb-3 mt-5" style="margin-left: 12rem" id="phases-switcher" role="tablist">
     <% @rating_types_by_phase.each do |phase, rating_types| %>
       <li class="nav-item">
@@ -45,6 +61,11 @@
           <% if project.stage %>
             <div class="mt-1">
               <span class="badge badge-secondary" title="Prebiehajúca fáza"><%= project.stage %></span>
+            </div>
+          <% end %>
+          <% translate_tags(project.tags).each do |tag| %>
+            <div class="mt-1">
+              <span class="badge badge-info" title="Hodnotené"><%= tag %></span>
             </div>
           <% end %>
         </td>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -2,21 +2,15 @@
   <h1 class="mt-5 mb-3">Zoznam hodnotených projektov</h1>
   <p class="lead"><strong>Chýba Vám tu nejaký projekt? Nezdá sa Vám hodnotenie?</strong> Toto hodnotenie je možné <%= link_to 'dopĺňať a upravovať', contribute_path %>.</p>
 
-  <form action=<%= projects_path %>>
+
+  <%= form_tag projects_path, method: :get do %>
     <div class="form-row">
       <div class="form-group mb-2 col-sm-4">
-        <select name="tag" class="form-control">
-          <option value="">Všetky tagy</option>
-          <% @filter["available"].each do |tag, translated| %>
-            <option value="<%= tag %>" <%= @filter["tag"] == tag ? 'selected' : '' %>><%= translated %></option>
-          <% end %>
-        </select>
+        <%= select_tag :tag, options_for_select([["Zobraziť všetko", ""]] + ProjectsHelper::ALLOWED_TAGS.map{ |tag, trans| [trans, tag] }, @selected_tag), class: "form-control" %>
       </div>
-      <div class="form-group mb-2 col-sm-2">
-        <input type="submit" value="Filtrovať podľa tagu" class="btn mb-2">
-      </div>
+      <%= submit_tag "Filtrovať", class: "btn mb-2" %>
     </div>
-  </form>
+  <% end %>
 
   <ul class="nav nav-pills mb-3 mt-5" style="margin-left: 12rem" id="phases-switcher" role="tablist">
     <% @rating_types_by_phase.each do |phase, rating_types| %>
@@ -61,11 +55,6 @@
           <% if project.stage %>
             <div class="mt-1">
               <span class="badge badge-secondary" title="Prebiehajúca fáza"><%= project.stage %></span>
-            </div>
-          <% end %>
-          <% translate_tags(project.tags).each do |tag| %>
-            <div class="mt-1">
-              <span class="badge badge-info" title="Hodnotené"><%= tag %></span>
             </div>
           <% end %>
         </td>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,7 +4,6 @@
   <div class="row mb-5">
     <div class="col-md-12">
       <h1 class="project-title"><%= @project.title %></h1>
-      <% if @project.tags.map { |tag| ProjectsHelper::ALLOWED_TAGS[tag] }.present? %>
         <% @project.tags.map { |tag| [ProjectsHelper::ALLOWED_TAGS[tag], tag] if ProjectsHelper::ALLOWED_TAGS[tag]}.each do |translated, tag| %>
           <p class="lead">
             <%= link_to projects_path(tag: tag) do%>
@@ -12,7 +11,6 @@
             <% end %>
           </p>
         <% end %>
-      <% end %>
       <p class="lead text-muted mt-4"><%= @project.description %></p>
     </div>
   </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,6 +4,17 @@
   <div class="row mb-5">
     <div class="col-md-12">
       <h1 class="project-title"><%= @project.title %></h1>
+      <% if translate_tags(@project.tags).present? %>
+        <div class="row mb-5">
+          <div class="col-md-12">
+            <h2>
+              <% translate_tags(@project.tags).each do |tag| %>
+                <span class="badge badge-info"><%= tag %></span>
+              <% end %>
+            </h2>
+          </div>
+        </div>
+      <% end %>
       <p class="lead text-muted mt-4"><%= @project.description %></p>
     </div>
   </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,16 +4,14 @@
   <div class="row mb-5">
     <div class="col-md-12">
       <h1 class="project-title"><%= @project.title %></h1>
-      <% if translate_tags(@project.tags).present? %>
-        <div class="row mb-5">
-          <div class="col-md-12">
-            <h2>
-              <% translate_tags(@project.tags).each do |tag| %>
-                <span class="badge badge-info"><%= tag %></span>
-              <% end %>
-            </h2>
-          </div>
-        </div>
+      <% if @project.tags.map { |tag| ProjectsHelper::ALLOWED_TAGS[tag] }.present? %>
+        <% @project.tags.map { |tag| [ProjectsHelper::ALLOWED_TAGS[tag], tag] if ProjectsHelper::ALLOWED_TAGS[tag]}.each do |translated, tag| %>
+          <p class="lead">
+            <%= link_to projects_path(tag: tag) do%>
+            <span class="badge badge-danger"><%= translated %></span>
+            <% end %>
+          </p>
+        <% end %>
       <% end %>
       <p class="lead text-muted mt-4"><%= @project.description %></p>
     </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,10 +4,10 @@
   <div class="row mb-5">
     <div class="col-md-12">
       <h1 class="project-title"><%= @project.title %></h1>
-        <% @project.tags.map { |tag| [ProjectsHelper::ALLOWED_TAGS[tag], tag] if ProjectsHelper::ALLOWED_TAGS[tag]}.each do |translated, tag| %>
+        <% @project.tags.select { |tag| ProjectsHelper::ALLOWED_TAGS[tag] }.each do |tag| %>
           <p class="lead">
             <%= link_to projects_path(tag: tag) do%>
-            <span class="badge badge-danger"><%= translated %></span>
+            <span class="badge badge-danger"><%= ProjectsHelper::ALLOWED_TAGS[tag] %></span>
             <% end %>
           </p>
         <% end %>


### PR DESCRIPTION
Projekty vieme na adrese `projekty?tag=xxx` filtrovať podľa tagov `hodnotene-sd`, `hodnotene-rfza`, `hodnotene-komunitou` a prekladajú sa userovi na `Hodnotené tímom Slovensko.Digital`, `Hodnotené tímom Žilina`, `Hodnotené Komunitou`. Zobrazuje sa to takto pod názvom projektu v tabuľke tyrkysovým info badgom:

![Screenshot from 2022-02-14 23-37-25](https://user-images.githubusercontent.com/12500066/153960376-940051be-fe22-4258-9ee5-52eff6cf394d.png)

Keď nie je vybraný žiadny filter, v dropdowne je vybrané `Všetky tagy`:

![Screenshot from 2022-02-14 23-37-45](https://user-images.githubusercontent.com/12500066/153960374-d08c9215-6331-4bfa-b620-c602365fe1db.png)

V detaile projektu je potom tag zobrazený zase ako info badge pod názvom projektu vo vnútri h2, aby to bolo "veľké ako pill":

![Screenshot from 2022-02-14 23-38-20](https://user-images.githubusercontent.com/12500066/153960373-cd512613-325b-4a43-a6f9-e71357902f7c.png)

Ak je tagov viac, sú vedľa seba:

![Screenshot from 2022-02-14 23-38-39](https://user-images.githubusercontent.com/12500066/153960371-d7cb7786-e73a-4ec1-bde2-e1685512bd9f.png)


Keďže sme to mali prekladať zatiaľ staticky v kóde, pridal som do `ProjectsHelper` atribút `self.available_tags` taký dictionary na prekladanie. Ďalej som tam pridal funkciu `translate_tags(tags)`, ktorú potom volám vo views a prekladá tagy projektu na tie translated a rovno ich aj filtruje na tie tri zadané. Ak by sme chceli meniť zoznam tých prekladaných tagov, stačí zmeniť iba v `ProjectsHelper::self.available_tags`.

Filtrovanie sa potom robí v `ProjectsController`, kde sa opýtame, či zadaný parameter tag je v zozname prekladaných. Ak hej, projekty sa podľa neho vyfiltrujú a do atribútu `@filter["tag"]` uložíme aplikovaný tag filter, podľa ktorého sa nastaví selected vo view v dropdown.