### PR TITLE
RF-498/Documnet-description-parsing

### DIFF
--- a/db/migrate/20241212091706_change_description_to_text_in_phase_revisions.rb
+++ b/db/migrate/20241212091706_change_description_to_text_in_phase_revisions.rb
@@ -1,0 +1,5 @@
+class ChangeDescriptionToTextInPhaseRevisions < ActiveRecord::Migration[5.1]
+  def change
+    change_column :phase_revisions, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20240621112043) do
+ActiveRecord::Schema.define(version: 20241212091706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 20240621112043) do
     t.string "title", null: false
     t.string "full_name"
     t.string "guarantor"
-    t.string "description"
+    t.text "description"
     t.string "budget"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
- Opravena chyba kedy sa description parsoval len po prvy enter, teraz to prejde vsetky povolene elementy az po dalsi header.
- Zmena typu `string` -> `text` 