### PR TITLE
RF/Sync-all-topics-job-fix

### DIFF
--- a/app/jobs/sync_all_topics_job.rb
+++ b/app/jobs/sync_all_topics_job.rb
@@ -37,7 +37,7 @@ class SyncAllTopicsJob < ApplicationJob
   end
 
   def process_row_for_sync_all(project_name, project_id, platform_link, preparation_document_id, preparation_page_id, product_document_id, product_page_id)
-    if platform_link.present?
+    if platform_link == 'Platforma link'
       SyncTopicJob.perform_later(project_id, preparation_page_id)
     else
       enqueue_job_for_update("#{project_name} - Príprava", project_id, preparation_document_id, preparation_page_id, 'Prípravná fáza')

--- a/spec/jobs/sync_all_topics_job_spec.rb
+++ b/spec/jobs/sync_all_topics_job_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe SyncAllTopicsJob, type: :job do
         [],
         ['Projekt'],
         ['Projekt1', 'ABC1', '', 'ABC1', 'ABC1', 'ABC1', 'ABC1'],
-        ['Projekt2', 'ABC2', 'http://google.com', 'ABC2', 'ABC2', 'ABC2', 'ABC2']
+        ['Projekt2', 'ABC2', 'Platforma link', 'ABC2', 'ABC2', 'ABC2', 'ABC2']
       ]
     end
 
@@ -78,7 +78,7 @@ RSpec.describe SyncAllTopicsJob, type: :job do
         [],
         ['Projekt', 'Projekt ID', 'Platforma', 'ID draft prípravy', 'ID prípravy', 'ID draft produktu', 'ID produktu'],
         ['Projekt1', 'ABC1', '', 'ABC1', '', 'ABC1', ''],
-        ['Projekt2', 'ABC2', 'http://google.com', 'ABC2', 'ABC2', 'ABC2', 'ABC2']
+        ['Projekt2', 'ABC2', 'Platforma link', 'ABC2', 'ABC2', 'ABC2', 'ABC2']
       ]
     end
 


### PR DESCRIPTION
Pozeral som RF admina, boli tam nejake failnute joby. Dovod je, ze sa syncovali nove hodnotenia cez stary platforma system. Ten column v google tabulkach sa povodne na tieto nove hodnotenia nemal pouzivat, no pouziva sa tak som to adjustol.